### PR TITLE
Fix compilation failed error (issue #9)

### DIFF
--- a/template.qmd
+++ b/template.qmd
@@ -278,6 +278,7 @@ In {apatb-mymarkdowntable}, there is an example of using a plain markdown table 
 | 12      | 12   |    12 |   12   |
 | 123     | 123  |   123 |  123   |
 | 1       | 1    |     1 |   1    |
+
 ```
 
 


### PR DESCRIPTION
Fixes the compilation failed error (see below) when exporting as PDF with the new markdown table (#9).

I noticed that the closing backticks were messing with the table export. See line 98 in the `template.ttt` file:
`\textbackslash end\{table\} ``` `

Adding an empty line after the markdown table makes sure the end of the table is properly recognized. 
Now, line 98 in `template.ttt` is correct:
 `\end{table*}`

Error fixed:
```
compilation failed- error
File ended while scanning use of \efloat@xfloat.
<inserted text> 
                \par 
<*> template.tex
```