### PR TITLE
Unlock `opts_current` before calling `$set()`

### DIFF
--- a/_extensions/wjschne/apaquarto/_apa_title.qmd
+++ b/_extensions/wjschne/apaquarto/_apa_title.qmd
@@ -27,7 +27,9 @@ if (is_pdf) {
       
     }
     
+    opts_current$lock(FALSE)
     knitr::opts_current$set(output = "asis", fig.env = NULL)
+    opts_current$lock(TRUE)
     
     
     filename <- paste0(opts_knit$get("base.url"), paste(x, collapse = "."))


### PR DESCRIPTION
From knitr 1.44 on, `opts_current` will be locked. It is necessary to unlock it before calling `opts_current$set()`

See [The Upcoming knitr v1.44: More Compatible with Quarto, and Locking `opts_current`](https://yihui.org/en/2023/09/knitr-1-44/)

Fixes #16