### PR TITLE
Template: Add double quotes to strings to avoid syntax highlighting issues

### DIFF
--- a/template.qmd
+++ b/template.qmd
@@ -23,7 +23,7 @@ author:
       - Writing - original draft
     affiliations:
       - id: id1
-        name: Ana and Blanca's University
+        name: "Ana and Blanca's University"
         department: Department of Psychology
         address: 1234 Capital St.
         city: Albany
@@ -39,8 +39,8 @@ author:
     roles:
       - Formal Analysis
     affiliations:
-      - name: Carina's Primary Affiliation
-      - name: Carina's Secondary Affiliation
+      - name: "Carina's Primary Affiliation"
+      - name: "Carina's Secondary Affiliation"
     # Because Dolorita is unaffiliated, specify her city instead
   - name: Dolorita Perengana
     orcid: 0000-0000-0000-0003


### PR DESCRIPTION
On RStudio the YAML's syntax highlighting had issues due to the 2 first single quotes detected as character delimitation.
In general, explicitly using quotes can also prevent some special characters related problems