### PR TITLE
fixed typo in frontmatter.lua

### DIFF
--- a/_extensions/apaquarto/frontmatter.lua
+++ b/_extensions/apaquarto/frontmatter.lua
@@ -86,7 +86,7 @@ local get_author_paragraph = function(authors, different)
           sep = ""
         elseif i == #authors then
           if i == 2 then
-            sep = " " .. andreplacement .. ""
+            sep = " " .. andreplacement .. " "
           else
             sep = ", " .. andreplacement .. " "
           end


### PR DESCRIPTION
In documents with two authors, there is a space missing between the word "and" and the second author. I tracked down the issue to a missing space in line 89 in `frontmatter.lua`. Adding that space solved the issue, and I thought I could contribute to this great project. This is my first interaction with a GitHub repository and my first pull request. I hope I'm doing this correctly.