### PR TITLE
`https` for ORCiD url

### DIFF
--- a/_extensions/apaquarto/frontmatter.lua
+++ b/_extensions/apaquarto/frontmatter.lua
@@ -325,7 +325,7 @@ return {
           pp = pandoc.Para(pandoc.Str(""))
           pp.content:extend(a.apaauthordisplay)
           pp.content:extend({pandoc.Space(), img})
-          pp.content:extend({pandoc.Space(), pandoc.Str("http://orcid.org/")})
+          pp.content:extend({pandoc.Space(), pandoc.Str("https://orcid.org/")})
           pp.content:extend(a.orcid)
           
           if not mask and not meta["suppress-orcid"] and authornote then


### PR DESCRIPTION
ORCiD urls start with `http://` for the formats `apaquarto-typst`, `apaquarto-docx`, and `apaquarto-html`:
https://github.com/wjschne/apaquarto/blob/98c0137534514f4940fd16f4c9941ca1d6c4797e/_extensions/apaquarto/frontmatter.lua#L328
However, for `apaquarto-pdf` (i.e., LaTeX), ORCiD urls start with `https://`.

This PR adds the missing `s` in L328 of `frontmatter.lua` so that the output is consistent across formats.
