### PR TITLE
Update title.tex - add note metadata to title page

### DIFF
--- a/_extensions/apaquarto/title.tex
+++ b/_extensions/apaquarto/title.tex
@@ -42,6 +42,9 @@ $endif$
 $if(duedate)$
 \duedate{$duedate$}
 $endif$
+$if(note)$
+\note{$note$}
+$endif$
 
 $if(copyrightnotice)$
 \ccoppy{\textcopyright~$copyrightnotice$}


### PR DESCRIPTION
Add the the option of notes to title page

"Notation of manuscript date or other information desired beneath the affiliation line (not part of the APA 7th edition specification for title page)" (page 7 pdf, apa7  LATEX class). https://ctan.org/pkg/apa7