### PR TITLE
chore: remove duplicate longtable import

### DIFF
--- a/_extensions/apaquarto/header.tex
+++ b/_extensions/apaquarto/header.tex
@@ -13,7 +13,11 @@
 
 
 
-\usepackage{longtable, booktabs, multirow, multicol, colortbl, hhline, caption, array, float, xpatch}
+% longtable is already loaded via doc-class.tex (apa7 class option) and
+% apatemplate.tex (\RequirePackage{longtable}). Keep booktabs here so raw
+% LaTeX tables using \toprule/\midrule still render even without Pandoc table
+% nodes.
+\usepackage{booktabs, multirow, multicol, colortbl, hhline, caption, array, float, xpatch}
 \usepackage{subcaption}
 
 
@@ -49,5 +53,4 @@
 
 \usepackage{hyperref}
 \usepackage[protrusion=true]{microtype}
-
 


### PR DESCRIPTION
## Summary

This trims a duplicate LaTeX package import in `_extensions/apaquarto/header.tex`.

## Why

`longtable` is already provided by the class/template stack, so loading it again in `header.tex` is redundant.

## Change

- remove the redundant `longtable` import from `header.tex`
- keep `booktabs` loaded in `header.tex` so raw LaTeX tables using `\toprule` and `\midrule` still work even when Pandoc does not emit native table nodes
- add a short comment documenting that distinction

## Notes

No behavior change is intended. This keeps the existing `booktabs` coverage while removing only the duplicate `longtable` import.

Assistance note: I used AI coding tools to help draft and organize this patch. I reviewed the changes, validated the behavior locally, and take responsibility for the final PR.