### PR TITLE
fix: define CSL lengths defensively in PDF template

### DIFF
--- a/_extensions/apaquarto/apatemplate.tex
+++ b/_extensions/apaquarto/apatemplate.tex
@@ -261,6 +261,8 @@ $endif$
 
 $if(journalmode)$
 $else$
+\ifdefined\cslhangindent\else\newlength{\cslhangindent}\fi
+\ifdefined\csllabelwidth\else\newlength{\csllabelwidth}\fi
 \setlength{\cslhangindent}{0.5in}
 $endif$
 

--- a/tests/csl-length-compat.qmd
+++ b/tests/csl-length-compat.qmd
@@ -1,0 +1,19 @@
+---
+title: "CSL Length Compatibility Reproducer"
+shorttitle: "CSL lengths"
+author:
+  - name: Test Author
+    corresponding: true
+    email: test@example.com
+    affiliations:
+      - name: Test University
+bibliography: references.bib
+format:
+  apaquarto-pdf:
+    documentmode: man
+keep-tex: true
+---
+
+This document exercises the bibliography formatting path without any local header workaround.
+
+A citation should be enough to trigger CSL-related formatting [@schneiderCattellHornCarrollTheoryCognitive2018].


### PR DESCRIPTION
## Summary

This change defines `\cslhangindent` and `\csllabelwidth` defensively in the PDF template before setting the hanging indent.

## Why

In Quarto 1.9-era rendering, the template can reach `\setlength{\cslhangindent}{0.5in}` even when the CSL lengths were not defined earlier in the generated LaTeX. That forces downstream documents to add a local `include-in-header` workaround.

## Change

- define `\cslhangindent` if missing
- define `\csllabelwidth` if missing
- keep the existing manuscript-mode hanging-indent setting
- add `tests/csl-length-compat.qmd` as a minimal reproducer without a local workaround

## Notes

The included reproducer is meant to verify the fix directly in the extension repo.

Assistance note: I used AI coding tools to help draft and organize this patch. I reviewed the changes, validated the behavior locally, and take responsibility for the final PR.