### PR TITLE
Fix PDF crash with subfigures that each carry an apa-note (#158)

### DIFF
--- a/_extensions/apaquarto/apafloatlatex.lua
+++ b/_extensions/apaquarto/apafloatlatex.lua
@@ -193,6 +193,26 @@ local processfloat = function(float)
   end
 
   if float.type == "Figure" then
+    -- Don't wrap sub-figures in their own figure environment (nested figure
+    -- environments are illegal in latex); render natively and append the note
+    if float.parent_id then
+      if float.attributes["apa-note"] then
+        local subbeforenote = ""
+        float.content:walk {
+          Image = function(img)
+            if img.attributes["beforenotespace"] then
+              subbeforenote = "\\vspace{" .. img.attributes["beforenotespace"] .. "}\n"
+            end
+          end
+        }
+        local note_prefix = pandoc.Span(pandoc.RawInline("latex", subbeforenote .. noteprefix))
+        local subnote = utilsapa.make_note(float.attributes["apa-note"], note_prefix)
+        local newcontent = pandoc.Blocks(float.content)
+        newcontent:insert(subnote)
+        float.content = newcontent
+      end
+      return float
+    end
     local hasnote = false
     local apanote
     local twocolumn = false
@@ -251,13 +271,14 @@ local processfloat = function(float)
         floatposition = ""
       end
 
+      -- splice content as Blocks (a layout figure's content is a list, not a Block)
       local returnblock = pandoc.Div({
         pandoc.RawBlock("latex", "\\begin{" .. latexenv .. "}" .. floatposition),
-        captionspan,
-        float.content,
-        apanotedivs,
-        pandoc.RawBlock("latex", "\\end{" .. latexenv .. "}")
+        captionspan
       })
+      returnblock.content:extend(pandoc.Blocks(float.content))
+      returnblock.content:insert(apanotedivs)
+      returnblock.content:insert(pandoc.RawBlock("latex", "\\end{" .. latexenv .. "}"))
 
       return returnblock
     end

--- a/tests/issue-158-subfigure-notes.qmd
+++ b/tests/issue-158-subfigure-notes.qmd
@@ -1,0 +1,100 @@
+---
+title: "Subfigure Figure-Note Reproducer"
+shorttitle: "Issue 158"
+author:
+  - name: Test Author
+    corresponding: true
+    email: test@example.com
+    affiliations:
+      - name: Test University
+floatsintext: true
+keep-tex: true
+format:
+  apaquarto-pdf:
+    documentmode: man
+---
+
+<!--
+Reproducer for issue #158: rendering a figure made of multiple subfigures,
+each carrying an APA-style `apa-note`, crashed the apaquarto-pdf format with
+
+    Block, list of Blocks, or compatible element expected, got table
+    ...apaquarto/apafloatlatex.lua:254: in local 'filter_fn'
+
+and, once that crash was fixed, produced illegal nested LaTeX `figure`
+environments ("Not in outer par mode").
+
+Render from the repository root (so `_extensions/` and `sampleimage.png`
+resolve), e.g. by copying this file next to `example.qmd`:
+
+    cp tests/issue-158-subfigure-notes.qmd ./_issue158.qmd
+    quarto render _issue158.qmd --to apaquarto-pdf
+
+A successful run produces a PDF in which every figure note below is visible,
+every figure cross-reference resolves (no "Figure ??"), and no LaTeX
+"Not in outer par mode" error is raised.
+-->
+
+# 1. Single figure with a note (control)
+
+A lone figure with `apa-note` already worked; it must keep working
+(@fig-single).
+
+![A single image.](sampleimage.png){#fig-single width="2in"
+apa-note="This note belongs to a single, non-subfigure figure."}
+
+# 2. Subfigures, each with a note -- exactly as reported (the bug)
+
+This block matches the minimal example in issue #158: a subfigure layout with
+no overall caption, where each panel carries its own `apa-note`. Before the fix
+it crashed the PDF render (@fig-bug).
+
+::: {#fig-bug layout-ncol=2}
+![First panel.](sampleimage.png){#fig-bug-a width="2in"
+apa-note="Note for the first panel."}
+
+![Second panel.](sampleimage.png){#fig-bug-b width="2in"
+apa-note="Note for the second panel."}
+:::
+
+# 3. Subfigures with a note and an overall caption
+
+The same situation but with an overall figure caption (@fig-capnotes).
+
+::: {#fig-capnotes layout-ncol=2}
+![First panel.](sampleimage.png){#fig-capnotes-a width="2in"
+apa-note="Note for the first panel."}
+
+![Second panel.](sampleimage.png){#fig-capnotes-b width="2in"
+apa-note="Note for the second panel."}
+
+An overall caption for the whole figure.
+:::
+
+# 4. Subfigures where only one panel has a note (mixed)
+
+Only the second panel has a note; the first must render without one
+(@fig-mixed).
+
+::: {#fig-mixed layout-ncol=2}
+![Panel without a note.](sampleimage.png){#fig-mixed-a width="2in"}
+
+![Panel with a note.](sampleimage.png){#fig-mixed-b width="2in"
+apa-note="Only this panel has a note."}
+
+An overall caption for the mixed figure.
+:::
+
+# 5. A table with a note (untouched Table path)
+
+The table branch of the filter is unchanged; confirm it still works
+(@tbl-note).
+
+| Group | Value |
+|-------|-------|
+| A     | 1     |
+| B     | 2     |
+
+: A small table. {#tbl-note apa-note="This note belongs to the table."}
+
+Some text after the floats to confirm the document rendered completely.


### PR DESCRIPTION
Fixes #158.

## Problem

Rendering a subfigure layout (`::: {#fig-x layout-ncol=2}`) where each panel carries an APA-style `apa-note` crashed `apaquarto-pdf`. `apaquarto-docx` and `apaquarto-html` already handled this; only PDF failed.

There were two stacked problems in `apafloatlatex.lua`:

1. **The reported crash** — `pandoc.Div({…, float.content, …})`: for a single image `float.content` is one `Block`, but for a subfigure layout it is a `Blocks` *list*, which the `Div` constructor rejects:

   ```
   Block, list of Blocks, or compatible element expected, got table
       while retrieving function argument content
       while retrieving arguments for function Div
   ...apaquarto/apafloatlatex.lua:254: in local 'filter_fn'
   ```

2. **A hidden second bug** that the crash masked — `processfloat` runs on every `FloatRefTarget`, including each inner subfigure. Because each panel had a note, each got wrapped in its own `\begin{figure}…\end{figure}`, producing **nested figure environments**:

   ```
   ! LaTeX Error: Not in outer par mode.
   ```

## Fix

In `_extensions/apaquarto/apafloatlatex.lua`:

- **Sub-figures** (`float.parent_id ~= nil` — the same check Quarto uses to identify sub-floats) are no longer wrapped in their own `figure` environment. They render natively, with their `apa-note` appended below the image — mirroring the docx/html output.
- The **outer container** now splices `float.content` via `pandoc.Blocks(...)` instead of nesting it, so a `Blocks` list no longer crashes the `Div` constructor.

## Testing

Added `tests/issue-158-subfigure-notes.qmd`, a reproducer covering: a single figure + note (control), the exact issue case (subfigures each with a note, no overall caption), the captioned variant, a mixed case (only one panel noted), and a table + note.

Rendered in both `documentmode: man` and `documentmode: jou` on TeX Live 2026:

- No crash; valid PDF in both modes.
- All figure notes render (7/7), every cross-reference resolves (no `Figure ??`), and there are no nested `figure` environments (max nesting depth = 1).
- Visually confirmed each panel shows its note in both the manuscript and the two-column journal layouts.

## Note on layout (possible follow-up)

In PDF the panels stack vertically rather than side-by-side. That is the existing behavior of apaquarto's manual figure-wrapping (note-bearing figures never used minipages) — not a regression from this change, and cross-references resolve. I have a small prototype that makes subfigures render side-by-side (honoring `layout-ncol`) while keeping the notes, behind an opt-in toggle that defaults to today's vertical layout. Happy to open a separate issue to discuss it if that is of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
